### PR TITLE
manifest v3対応

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -62,7 +62,17 @@ urlChecker.addChecker(target => {
 });
 
 const fire = () => {
-	const text = getClipboardText().trim();
+	chrome.windows.create({
+		type: 'popup',
+		state: 'minimized',
+		url: './offscreen.html',
+	});
+};
+
+chrome.runtime.onMessage.addListener(message => {
+	if (message.type !== 'clipboard-text') return;
+
+	const text = message.text;
 	if (!text)  return;
 	const url = urlChecker.collectFirst(text) ||
 		// URLじゃなかったら検索
@@ -71,7 +81,7 @@ const fire = () => {
 	chrome.tabs.create({
 		url,
 	});
-};
+});
 
 // ショートカットキー
 chrome.commands.onCommand.addListener(command => {
@@ -81,19 +91,6 @@ chrome.commands.onCommand.addListener(command => {
 });
 
 chrome.browserAction.onClicked.addListener(fire);
-
-const getClipboardText = (() => {
-	const pasteTarget = document.createElement('div');
-	pasteTarget.contentEditable = true;
-	document.activeElement.appendChild(pasteTarget);
-	return () => {
-		pasteTarget.textContent = '';
-		pasteTarget.focus();
-		document.execCommand('Paste', null, null);
-		const clipboardText = pasteTarget.textContent;
-		return clipboardText;
-	};
-})();
 
 const generateGoogleSearchUrl = word => {
 	const queryObject = {

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,22 +1,20 @@
 {
 	"name": "Open clipboard data",
 	"version": "1.0.0",
-	"manifest_version": 2,
+	"manifest_version": 3,
 
 	"description": "クリップボードの中身を開く（URLの場合）か検索する（その他）",
 
 	"permissions": [
+		"offscreen",
 		"clipboardRead"
 	],
 
 	"background": {
-		"scripts": [
-			"background.js"
-		],
-		"persistent": false
+		"service_worker": "background.js"
 	},
 
-	"browser_action": {
+	"action": {
 		"default_title": "クリップボードの中身を開く（URLの場合）か検索する（その他）"
 	},
 

--- a/chrome-extension/offscreen.html
+++ b/chrome-extension/offscreen.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html><html><body>
+	<div contenteditable id="pasteTarget"></div>
+	<script src="offscreen.js"></script>
+</body></html>

--- a/chrome-extension/offscreen.js
+++ b/chrome-extension/offscreen.js
@@ -9,10 +9,8 @@ const getClipboardText = (() => {
 	};
 })();
 
-
-chrome.runtime.sendMessage({
-	type: 'clipboard-text',
-	text: getClipboardText(),
-}, () => {
-	window.close();
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+	if (message.type === 'read-clipboard-text') {
+		sendResponse(getClipboardText());
+	}
 });

--- a/chrome-extension/offscreen.js
+++ b/chrome-extension/offscreen.js
@@ -1,0 +1,18 @@
+const getClipboardText = (() => {
+	const pasteTarget = document.getElementById('pasteTarget');
+	return () => {
+		pasteTarget.textContent = '';
+		pasteTarget.focus();
+		document.execCommand('Paste', null, null);
+		const clipboardText = pasteTarget.textContent;
+		return clipboardText;
+	};
+})();
+
+
+chrome.runtime.sendMessage({
+	type: 'clipboard-text',
+	text: getClipboardText(),
+}, () => {
+	window.close();
+});


### PR DESCRIPTION
offscreen API を使用

## 参考
- [Manifest V3 に移行する  |  Chrome Extensions  |  Chrome for Developers](https://developer.chrome.com/docs/extensions/develop/migrate?hl=ja)
- [chrome.offscreen  |  API  |  Chrome for Developers](https://developer.chrome.com/docs/extensions/reference/api/offscreen?hl=ja)
- [Manifest V3 のオフスクリーン ドキュメント  |  Blog  |  Chrome for Developers](https://developer.chrome.com/blog/Offscreen-Documents-in-Manifest-v3?hl=ja)